### PR TITLE
fix getConnectons method to return actual number of uws connections like ws do

### DIFF
--- a/nodejs/src/uws.js
+++ b/nodejs/src/uws.js
@@ -392,6 +392,18 @@ class Server extends EventEmitter {
             if (options.path && (!options.path.length || options.path[0] !== '/')) {
                 options.path = '/' + options.path;
             }
+            
+            var nativeGetConnections = this.httpServer.getConnections.bind(this.httpServer);
+            this.httpServer.getConnections = (cb) => {
+                nativeGetConnections((err, httpConnections) => {
+                    var wsConnections = native.server.group.getSize(this.serverGroup);
+                    if (err) {
+                      cb(null, wsConnections);
+                      return;
+                    }
+                    cb(null, wsConnections + httpConnections)
+                });
+            }
 
             this.httpServer.on('upgrade', this._upgradeListener = ((request, socket, head) => {
                 if (!options.path || options.path == request.url.split('?')[0].split('#')[0]) {


### PR DESCRIPTION
In order to make it more compatible with 'ws' and other WebSocket server libs `http.getConnections` method should return number of active connections. Now it returns 0, when there are active uws connections, however when using 'ws' library it returns correct number.