### PR TITLE
support multiple subprotocols subscription

### DIFF
--- a/nodejs/src/uws.js
+++ b/nodejs/src/uws.js
@@ -486,7 +486,7 @@ class Server extends EventEmitter {
             if (this.serverGroup) {
                 _upgradeReq = request;
                 this._upgradeCallback = callback ? callback : noop;
-                native.upgrade(this.serverGroup, socket.external, secKey, request.headers['sec-websocket-extensions'], request.headers['sec-websocket-protocol']);
+                native.upgrade(this.serverGroup, socket.external, secKey, request.headers['sec-websocket-extensions'], request.headers['sec-websocket-protocol'].split(",").map(item=>item.trim())[0]);
             }
         } else {
             const secKey = request.headers['sec-websocket-key'];
@@ -499,7 +499,7 @@ class Server extends EventEmitter {
                     if (this.serverGroup) {
                         _upgradeReq = request;
                         this._upgradeCallback = callback ? callback : noop;
-                        native.upgrade(this.serverGroup, ticket, secKey, request.headers['sec-websocket-extensions'], request.headers['sec-websocket-protocol']);
+                        native.upgrade(this.serverGroup, ticket, secKey, request.headers['sec-websocket-extensions'], request.headers['sec-websocket-protocol'].split(",").map(item=>item.trim())[0]);
                     }
                 });
             }


### PR DESCRIPTION
the client can send an array of protocols but the server should reply with one only, otherwise connection handshake fails.
according to RFC6455:  The |Sec-WebSocket-Protocol| header field MAY appear multiple times in an HTTP request (which is logically the same as a single |Sec-WebSocket-Protocol| header field that contains all values).
However, the |Sec-WebSocket-Protocol| header field MUST NOT appear more than once in an HTTP response.
https://tools.ietf.org/html/rfc6455#page-59

After adding this change it was working and socket was established correctly.