### PR TITLE
extend internalOnClose to return the webSocket

### DIFF
--- a/nodejs/src/uws.js
+++ b/nodejs/src/uws.js
@@ -61,7 +61,7 @@ native.client.group.onDisconnection(clientGroup, (external, code, message, webSo
     webSocket.external = null;
 
     process.nextTick(() => {
-        webSocket.internalOnClose(code, message);
+        webSocket.internalOnClose(webSocket, code, message);
     });
 
     native.clearUserData(external);
@@ -117,7 +117,7 @@ class WebSocket {
 
     set onclose(f) {
         if (f) {
-            this.internalOnClose = (code, message) => {
+            this.internalOnClose = (webSocket, code, message) => {
                 f({code: code, reason: message});
             };
         } else {
@@ -137,7 +137,7 @@ class WebSocket {
         if (eventName === 'message') {
             this.internalOnMessage(arg1);
         } else if (eventName === 'close') {
-            this.internalOnClose(arg1, arg2);
+            this.internalOnClose(arg1, arg2, arg3);
         } else if (eventName === 'ping') {
             this.onping(arg1);
         } else if (eventName === 'pong') {
@@ -194,7 +194,7 @@ class WebSocket {
             if (this.internalOnClose !== noop) {
                 throw Error(EE_ERROR);
             }
-            this.internalOnClose = (code, message) => {
+            this.internalOnClose = (webSocket, code, message) => {
                 this.internalOnClose = noop;
                 f(code, message);
             };
@@ -442,7 +442,7 @@ class Server extends EventEmitter {
             webSocket.external = null;
 
             process.nextTick(() => {
-                webSocket.internalOnClose(code, message);
+                webSocket.internalOnClose(webSocket, code, message);
             });
 
             native.clearUserData(external);


### PR DESCRIPTION
in my scenario I have multiple clients connected and subscribed to different subprotocols so I have to manage the clients myself and can't use get clients.
so in case of disconnect I need to know which client got disconnected so the onClose event need to return the webSocket.
(I add unique ID the each webSocket on connection so I know to identify it when it disconnects)